### PR TITLE
Remove outline from textarea

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@ html, body {
   width: 95%;
   max-width: 600px;
   resize: none;
+  outline: none;
   border: 0;
   font-size: 20pt;
   color: inherit;


### PR DESCRIPTION
Add `outline: none` to remove the outline when focused in some browsers